### PR TITLE
Fix event params

### DIFF
--- a/server/SlackBot.ts
+++ b/server/SlackBot.ts
@@ -60,7 +60,7 @@ export class SlackBot extends Bot {
 
             const eventAdapter = createEventAdapter(signingSecret, { includeBody: true });
 
-            eventAdapter.on('app_mention', async ({ event, body }) => {
+            eventAdapter.on('app_mention', async (event, body) => {
                 await this.processSlackMessage(body, event);
             });
 


### PR DESCRIPTION
I don't know why Slack didn't define types for any of this, or why each of their libraries behaves very slightly differently...