### PR TITLE
Fix bugs in leave operation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "name": "Debug Server",
             "skipFiles": ["<node_internals>/**"],
             "program": "${workspaceFolder}/server/.build/server.js",
-            "preLaunchTask": "tsc: build - server/tsconfig.json",
+            "preLaunchTask": "tsc: build - server/tsconfig-debug.json",
             "envFile": "${workspaceFolder}/EpycDebug.sh",
             "env": {
                 "BUILD_TYPE": "DEV"

--- a/server/tsconfig-debug.json
+++ b/server/tsconfig-debug.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "incremental": true
+    }
+}


### PR DESCRIPTION
- Leaving in a cross-channel game didn't work properly
- Leaving as the last player in the game would sometimes cause the game state to become inconsistent
- Add unit tests for leave operation
- Use incremental builds when locally debugging